### PR TITLE
Support es5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 script: npm run test-ci
 node_js:
+  - "0.12"
   - 4

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,11 @@
-const assert = require('power-assert')
-const StaticFilesWebpackPlugin = require('..')
-const rmrf = require('rimraf')
-const path = require('path')
-const fs = require('fs')
-const webpack = require('webpack')
+var assert = require('power-assert')
+var StaticFilesWebpackPlugin = require('..')
+var rmrf = require('rimraf')
+var path = require('path')
+var fs = require('fs')
+var webpack = require('webpack')
 
-const isWin = /^win/.test(process.platform)
+var isWin = /^win/.test(process.platform)
 
 var publicFilePathRegexp
 if (isWin) {
@@ -14,42 +14,42 @@ if (isWin) {
   publicFilePathRegexp = /^\/bundles\/\w+\.gif$/
 }
 
-describe('StaticFilesWebpackPlugin', () => {
-  afterEach((done) => {
-    rmrf(path.join(__dirname, 'dist'), () => {
-      rmrf(path.join(__dirname, 'static.json'), () => {
-        rmrf(path.join(process.cwd(), 'static.json'), () => {
+describe('StaticFilesWebpackPlugin', function() {
+  afterEach(function(done) {
+    rmrf(path.join(__dirname, 'dist'), function() {
+      rmrf(path.join(__dirname, 'static.json'), function() {
+        rmrf(path.join(process.cwd(), 'static.json'), function() {
           rmrf(path.join(process.cwd(), 'wut.json'), done)
         })
       })
     })
   })
 
-  it('stores paths to resolved static files', (done) => {
+  it('stores paths to resolved static files', function(done) {
     var compiler = webpack({
       context: __dirname,
       entry: './fixtures/index.js',
       plugins: [
         new StaticFilesWebpackPlugin()
-      ]
+      ],
       output: {
         path: path.join(__dirname, 'dist'),
         filename: 'bundle.js',
         publicPath: '/bundles'
       }
     })
-    compiler.run((err, stats) => {
+    compiler.run(function(err, stats) {
       assert(!err)
-      fs.readFile(path.join(process.cwd(), 'static.json'), (err, content) => {
+      fs.readFile(path.join(process.cwd(), 'static.json'), function(err, content) {
         assert(!err)
-        const staticFiles = JSON.parse(content.toString())
-        const fileNames = Object.keys(staticFiles)
+        var staticFiles = JSON.parse(content.toString())
+        var fileNames = Object.keys(staticFiles)
         assert.deepEqual(fileNames.sort(), [
           path.join(__dirname, 'fixtures', 'static', 'a.gif'),
           path.join(__dirname, 'fixtures', 'static', 'b.gif'),
           path.join(__dirname, 'fixtures', 'static', 'c.gif')
         ])
-        fileNames.forEach((fileName) => {
+        fileNames.forEach(function(fileName) {
           assert(staticFiles[fileName].match(publicFilePathRegexp))
         })
         done()
@@ -57,10 +57,10 @@ describe('StaticFilesWebpackPlugin', () => {
     })
   })
 
-  describe('options', () => {
-    describe('outputPath', () => {
-      context('when the option is an absolute path', () => {
-        it('stores paths to resolved static files', (done) => {
+  describe('options', function() {
+    describe('outputPath', function() {
+      context('when the option is an absolute path', function() {
+        it('stores paths to resolved static files', function(done) {
           var compiler = webpack({
             context: __dirname,
             entry: './fixtures/index.js',
@@ -68,25 +68,25 @@ describe('StaticFilesWebpackPlugin', () => {
               new StaticFilesWebpackPlugin({
                 outputPath: path.join(__dirname, 'dist', 'static.json')
               })
-            ]
+            ],
             output: {
               path: path.join(__dirname, 'dist'),
               filename: 'bundle.js',
               publicPath: '/bundles'
             }
           })
-          compiler.run((err, stats) => {
+          compiler.run(function(err, stats) {
             assert(!err)
-            fs.readFile(path.join(__dirname, 'dist', 'static.json'), (err, content) => {
+            fs.readFile(path.join(__dirname, 'dist', 'static.json'), function(err, content) {
               assert(!err)
-              const staticFiles = JSON.parse(content.toString())
-              const fileNames = Object.keys(staticFiles)
+              var staticFiles = JSON.parse(content.toString())
+              var fileNames = Object.keys(staticFiles)
               assert.deepEqual(fileNames.sort(), [
                 path.join(__dirname, 'fixtures', 'static', 'a.gif'),
                 path.join(__dirname, 'fixtures', 'static', 'b.gif'),
                 path.join(__dirname, 'fixtures', 'static', 'c.gif')
               ])
-              fileNames.forEach((fileName) => {
+              fileNames.forEach(function(fileName) {
                 assert(staticFiles[fileName].match(publicFilePathRegexp))
               })
               done()
@@ -95,8 +95,8 @@ describe('StaticFilesWebpackPlugin', () => {
         })
       })
 
-      context('when the option is a relative path', () => {
-        it('stores paths to resolved static files using process.cwd as a base', (done) => {
+      context('when the option is a relative path', function() {
+        it('stores paths to resolved static files using process.cwd as a base', function(done) {
           var compiler = webpack({
             context: __dirname,
             entry: './fixtures/index.js',
@@ -104,25 +104,25 @@ describe('StaticFilesWebpackPlugin', () => {
               new StaticFilesWebpackPlugin({
                 outputPath: 'wut.json'
               })
-            ]
+            ],
             output: {
               path: path.join(__dirname, 'dist'),
               filename: 'bundle.js',
               publicPath: '/bundles'
             }
           })
-          compiler.run((err, stats) => {
+          compiler.run(function(err, stats) {
             assert(!err)
-            fs.readFile(path.join(process.cwd(), 'wut.json'), (err, content) => {
+            fs.readFile(path.join(process.cwd(), 'wut.json'), function(err, content) {
               assert(!err)
-              const staticFiles = JSON.parse(content.toString())
-              const fileNames = Object.keys(staticFiles)
+              var staticFiles = JSON.parse(content.toString())
+              var fileNames = Object.keys(staticFiles)
               assert.deepEqual(fileNames.sort(), [
                 path.join(__dirname, 'fixtures', 'static', 'a.gif'),
                 path.join(__dirname, 'fixtures', 'static', 'b.gif'),
                 path.join(__dirname, 'fixtures', 'static', 'c.gif')
               ])
-              fileNames.forEach((fileName) => {
+              fileNames.forEach(function(fileName) {
                 assert(staticFiles[fileName].match(publicFilePathRegexp))
               })
               done()
@@ -132,9 +132,9 @@ describe('StaticFilesWebpackPlugin', () => {
       })
     })
 
-    describe('useRelativePaths', () => {
-      context('when useRelativePaths is true', () => {
-        it('stores relative paths to resolved static files', (done) => {
+    describe('useRelativePaths', function() {
+      context('when useRelativePaths is true', function() {
+        it('stores relative paths to resolved static files', function(done) {
           var compiler = webpack({
             context: __dirname,
             entry: './fixtures/index.js',
@@ -142,25 +142,25 @@ describe('StaticFilesWebpackPlugin', () => {
               new StaticFilesWebpackPlugin({
                 useRelativePaths: true
               })
-            ]
+            ],
             output: {
               path: path.join(__dirname, 'dist'),
               filename: 'bundle.js',
               publicPath: '/bundles'
             }
           })
-          compiler.run((err, stats) => {
+          compiler.run(function(err, stats) {
             assert(!err)
-            fs.readFile(path.join(process.cwd(), 'static.json'), (err, content) => {
+            fs.readFile(path.join(process.cwd(), 'static.json'), function(err, content) {
               assert(!err)
-              const staticFiles = JSON.parse(content.toString())
-              const fileNames = Object.keys(staticFiles)
+              var staticFiles = JSON.parse(content.toString())
+              var fileNames = Object.keys(staticFiles)
               assert.deepEqual(fileNames.sort(), [
                 path.join('test', 'fixtures', 'static', 'a.gif'),
                 path.join('test', 'fixtures', 'static', 'b.gif'),
                 path.join('test', 'fixtures', 'static', 'c.gif')
               ])
-              fileNames.forEach((fileName) => {
+              fileNames.forEach(function(fileName) {
                 assert(staticFiles[fileName].match(publicFilePathRegexp))
               })
               done()
@@ -169,8 +169,8 @@ describe('StaticFilesWebpackPlugin', () => {
         })
       })
 
-      context('when useRelativePaths is an absolute path', () => {
-        it('stores relative paths to resolved static files', (done) => {
+      context('when useRelativePaths is an absolute path', function() {
+        it('stores relative paths to resolved static files', function(done) {
           var compiler = webpack({
             context: __dirname,
             entry: './fixtures/index.js',
@@ -178,25 +178,25 @@ describe('StaticFilesWebpackPlugin', () => {
               new StaticFilesWebpackPlugin({
                 useRelativePaths: path.join(process.cwd(), 'test', 'fixtures')
               })
-            ]
+            ],
             output: {
               path: path.join(__dirname, 'dist'),
               filename: 'bundle.js',
               publicPath: '/bundles'
             }
           })
-          compiler.run((err, stats) => {
+          compiler.run(function(err, stats) {
             assert(!err)
-            fs.readFile(path.join(process.cwd(), 'static.json'), (err, content) => {
+            fs.readFile(path.join(process.cwd(), 'static.json'), function(err, content) {
               assert(!err)
-              const staticFiles = JSON.parse(content.toString())
-              const fileNames = Object.keys(staticFiles)
+              var staticFiles = JSON.parse(content.toString())
+              var fileNames = Object.keys(staticFiles)
               assert.deepEqual(fileNames.sort(), [
                 path.join('static', 'a.gif'),
                 path.join('static', 'b.gif'),
                 path.join('static', 'c.gif')
               ])
-              fileNames.forEach((fileName) => {
+              fileNames.forEach(function(fileName) {
                 assert(staticFiles[fileName].match(publicFilePathRegexp))
               })
               done()
@@ -205,8 +205,8 @@ describe('StaticFilesWebpackPlugin', () => {
         })
       })
 
-      context('when useRelativePaths is a relative path', () => {
-        it('stores relative paths to resolved static files', (done) => {
+      context('when useRelativePaths is a relative path', function() {
+        it('stores relative paths to resolved static files', function(done) {
           var compiler = webpack({
             context: __dirname,
             entry: './fixtures/index.js',
@@ -214,25 +214,25 @@ describe('StaticFilesWebpackPlugin', () => {
               new StaticFilesWebpackPlugin({
                 useRelativePaths: path.join('test', 'fixtures')
               })
-            ]
+            ],
             output: {
               path: path.join(__dirname, 'dist'),
               filename: 'bundle.js',
               publicPath: '/bundles'
             }
           })
-          compiler.run((err, stats) => {
+          compiler.run(function(err, stats) {
             assert(!err)
-            fs.readFile(path.join(process.cwd(), 'static.json'), (err, content) => {
+            fs.readFile(path.join(process.cwd(), 'static.json'), function(err, content) {
               assert(!err)
-              const staticFiles = JSON.parse(content.toString())
-              const fileNames = Object.keys(staticFiles)
+              var staticFiles = JSON.parse(content.toString())
+              var fileNames = Object.keys(staticFiles)
               assert.deepEqual(fileNames.sort(), [
                 path.join('static', 'a.gif'),
                 path.join('static', 'b.gif'),
                 path.join('static', 'c.gif')
               ])
-              fileNames.forEach((fileName) => {
+              fileNames.forEach(function(fileName) {
                 assert(staticFiles[fileName].match(publicFilePathRegexp))
               })
               done()


### PR DESCRIPTION
A lot of people still use Node JS 0.12 and are not able to use the harmony flags, so I think it would make sense to support these environments by only using es5 features.

Requires this to be released first: https://github.com/kossnocorp/static-file-loader/pull/1 and the version of the static-file-loader bumped to the newest version when it is ready. 
