### PR TITLE
Make sure that the keys in the resulting map is always sorted.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,12 @@ StaticFilesWebpackPlugin.prototype.apply = function(compiler) {
       }, {})
     }
 
+    // Ensure that the keys in the map are sorted
+    map = Object.keys(map).sort().reduce(function(mapAcc, filePath) {
+      mapAcc[filePath] = map[filePath]
+      return mapAcc
+    }, {})
+
     fs.writeFile(this.options.outputPath, JSON.stringify(map), function(err) {
       if (err) throw err
       callback()


### PR DESCRIPTION
This will avoid generating file changes across builds when is it not
necessary. Especially this will avoid production hashes to change across
builds when the file map is included in the production build.
