### PR TITLE
Relative paths replace

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,19 +131,38 @@ new StaticFilesWebpackPlugin({
 
 ### `prefix`
 
-Sometimes it's instrumental to be able to swap relative path base with an arbitrary prefix
-instead of just removing it.
+Use `prefix` for replacing the string part of the path that was passed to
+`useRelativePaths`.
 
 ```js
 new StaticFilesWebpackPlugin({
   useRelativePaths: 'ui/static',
-  prefix: 'other/folder'
+  prefix: 'vendor/ui'
 })
 ```
 
 ```json
 {
-  "other/folder/img/favicon.png": "/e09ef13032827f865ef8004c185277f7.png"
+  "vendor/ui/img/favicon.png": "/e09ef13032827f865ef8004c185277f7.png"
+}
+```
+
+### `replace`
+
+Use `replace` for rewriting the resulting relative paths. For example,
+when some static assets are symlinked from the different folder you might want to
+replace specific part of the path.
+
+```js
+new StaticFilesWebpackPlugin({
+  useRelativePaths: true,
+  replace: (processedPath) => { processedPath.replace('img', 'static/img') }
+})
+```
+
+```json
+{
+  "static/img/favicon.png": "/e09ef13032827f865ef8004c185277f7.png"
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ function StaticFilesWebpackPlugin (options) {
   this.options = {
     outputPath: outputPath,
     useRelativePaths: options.useRelativePaths,
-    prefix: options.prefix
+    prefix: options.prefix,
+    replace: options.replace || function (processedPath) { return processedPath }
   }
 }
 
@@ -33,9 +34,12 @@ StaticFilesWebpackPlugin.prototype.apply = function (compiler) {
         relativePathBase = process.cwd()
       }
 
+      var replace = this.options.replace
       var prefix = this.options.prefix ? this.options.prefix + path.sep : ''
       map = Object.keys(map).reduce(function (mapAcc, filePath) {
-        mapAcc[filePath.replace(relativePathBase + path.sep, prefix)] = map[filePath]
+        var relativePath = filePath.replace(relativePathBase + path.sep, prefix)
+        relativePath = replace(relativePath)
+        mapAcc[relativePath] = map[filePath]
         return mapAcc
       }, {})
     }

--- a/test/index.js
+++ b/test/index.js
@@ -263,41 +263,83 @@ describe('StaticFilesWebpackPlugin', function () {
         })
       })
     })
-  })
 
-  describe('prefix', function () {
-    context('when prefix is set and useRelativePaths is a string', function () {
-      it('replaces the relative path base with the prefix', function (done) {
-        var compiler = webpack({
-          context: __dirname,
-          entry: './fixtures/index.js',
-          plugins: [
-            new StaticFilesWebpackPlugin({
-              useRelativePaths: 'test/fixtures',
-              prefix: path.join('doot', 'noot')
-            })
-          ],
-          output: {
-            path: path.join(__dirname, 'dist'),
-            filename: 'bundle.js',
-            publicPath: '/bundles'
-          }
-        })
-        compiler.run(function (err, stats) {
-          assert(!err)
-          fs.readFile(path.join(process.cwd(), 'static.json'), function (err, content) {
+    describe('prefix', function () {
+      context('when useRelativePaths is truthy', function () {
+        it('replaces the relative path base with the prefix', function (done) {
+          var compiler = webpack({
+            context: __dirname,
+            entry: './fixtures/index.js',
+            plugins: [
+              new StaticFilesWebpackPlugin({
+                useRelativePaths: 'test/fixtures',
+                prefix: path.join('doot', 'noot')
+              })
+            ],
+            output: {
+              path: path.join(__dirname, 'dist'),
+              filename: 'bundle.js',
+              publicPath: '/bundles'
+            }
+          })
+          compiler.run(function (err, stats) {
             assert(!err)
-            var staticFiles = JSON.parse(content.toString())
-            var fileNames = Object.keys(staticFiles)
-            assert.deepEqual(fileNames.sort(), [
-              path.join('doot', 'noot', 'static', 'a.gif'),
-              path.join('doot', 'noot', 'static', 'b.gif'),
-              path.join('doot', 'noot', 'static', 'c.gif')
-            ])
-            fileNames.forEach(function (fileName) {
-              assert(staticFiles[fileName].match(publicFilePathRegexp))
+            fs.readFile(path.join(process.cwd(), 'static.json'), function (err, content) {
+              assert(!err)
+              var staticFiles = JSON.parse(content.toString())
+              var fileNames = Object.keys(staticFiles)
+              assert.deepEqual(fileNames.sort(), [
+                path.join('doot', 'noot', 'static', 'a.gif'),
+                path.join('doot', 'noot', 'static', 'b.gif'),
+                path.join('doot', 'noot', 'static', 'c.gif')
+              ])
+              fileNames.forEach(function (fileName) {
+                assert(staticFiles[fileName].match(publicFilePathRegexp))
+              })
+              done()
             })
-            done()
+          })
+        })
+      })
+    })
+
+    describe('replace', function () {
+      context('when useRelativePaths is truthy', function () {
+        it('runs replace function on the normalized relative paths', function (done) {
+          var compiler = webpack({
+            context: __dirname,
+            entry: './fixtures/index.js',
+            plugins: [
+              new StaticFilesWebpackPlugin({
+                useRelativePaths: true,
+                replace: function (processedPath) {
+                  return processedPath
+                    .replace(path.join('test', 'fixtures'), path.join('doot', 'noot'))
+                }
+              })
+            ],
+            output: {
+              path: path.join(__dirname, 'dist'),
+              filename: 'bundle.js',
+              publicPath: '/bundles'
+            }
+          })
+          compiler.run(function (err, stats) {
+            assert(!err)
+            fs.readFile(path.join(process.cwd(), 'static.json'), function (err, content) {
+              assert(!err)
+              var staticFiles = JSON.parse(content.toString())
+              var fileNames = Object.keys(staticFiles)
+              assert.deepEqual(fileNames.sort(), [
+                path.join('doot', 'noot', 'static', 'a.gif'),
+                path.join('doot', 'noot', 'static', 'b.gif'),
+                path.join('doot', 'noot', 'static', 'c.gif')
+              ])
+              fileNames.forEach(function (fileName) {
+                assert(staticFiles[fileName].match(publicFilePathRegexp))
+              })
+              done()
+            })
           })
         })
       })


### PR DESCRIPTION
Add more customizable way of rewriting/replacing parts of the resulting relative asset path.